### PR TITLE
Several bugfixes 401 error handling

### DIFF
--- a/src/Managers/CookieManager.php
+++ b/src/Managers/CookieManager.php
@@ -51,6 +51,11 @@ class CookieManager
 
         return $this->decryptCookieContent($parsedCookie);
     }
+    
+    public function exists()
+    {
+        return Cookie::has($this->info[CookieManager::COOKIE_NAME]);
+    }
 
     /**
      * @param array $content

--- a/src/Managers/RequestManager.php
+++ b/src/Managers/RequestManager.php
@@ -219,14 +219,14 @@ class RequestManager
               $options = array_add($options, 'form_params', $inputs);
             
             } elseif (Request::matchesType($contentType, 'multipart/form-data')) {
+                $options['multipart'] = [];
 
                 // filter through all file inputs instances and append them to guzzle multipart option
                 foreach (request()->files as $inputName => $file) {
-                    if ($file instanceof \Symfony\Component\HttpFoundation\File\UploadedFile);
-                    $options['multipart'] = [];
-                    $options['multipart'][] = ['name' => $inputName, 'contents' => file_get_contents($file->getRealPath()), 'filename' => $file->getClientOriginalName()];
+                    $options['multipart'][] = ['name' => $inputName, 'contents' => file_get_contents($file->getRealPath()), 'filename' => $file->getClientOriginalName(), 'description' => @$inputs[$inputName]['description']];
                 }
-                $options = array_add($options, 'multipart', $inputs);
+
+//                $options = array_add($options, 'multipart', $inputs);
 
             } else {
             

--- a/src/Models/ProxyResponse.php
+++ b/src/Models/ProxyResponse.php
@@ -19,13 +19,15 @@ class ProxyResponse
     private $reasonPhrase = null;
     private $protocolVersion = null;
     private $content = null;
+    private $parsedContent = null;
 
-    public function __construct($statusCode, $reasonPhrase, $protoVersion, $content)
+    public function __construct($statusCode, $reasonPhrase, $protoVersion, $content, $contentType)
     {
         $this->statusCode = $statusCode;
         $this->reasonPhrase = $reasonPhrase;
         $this->protocolVersion = $protoVersion;
         $this->content = $content;
+        $this->contentType = $contentType;
     }
 
     public function setStatusCode($status)
@@ -66,5 +68,25 @@ class ProxyResponse
     public function getContent()
     {
         return $this->content;
+    }
+    
+    public static function parseContent($contentType, $content)
+    {
+        switch ($contentType) {
+            case 'application/json':
+                return json_decode($content, true);
+
+            default:
+                return $content;
+        }
+    }
+    
+    public function getParsedContent()
+    {
+        if ($this->parsedContent === null) {
+            $this->parsedContent = self::parseContent($this->contentType, $this->content);
+        }
+        
+        return $this->parsedContent;
     }
 }

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -179,6 +179,7 @@ class Proxy
         $tokenUrl = $this->guestAccessTokens[$clientId];
         $clientSecret = $this->clientSecrets[$clientId];
         $client = new Client();
+
         $response = $client->post($tokenUrl, [
             'form_params' => [
                 ProxyAux::CLIENT_ID => $clientId,

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -23,6 +23,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;
+use Manukn\LaravelProxify\Models\ProxyResponse;
 
 class Proxy
 {

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -224,7 +224,10 @@ class Proxy
             return;
         }
         
-        return RequestManager::getResponseContent($response);
+        $contentType = $response->getHeaderLine('content-type');
+        $content = $response->getBody();
+        
+        return ProxyResponse::parseContent($contentType, $content);
     }
 
     /**


### PR DESCRIPTION
I hope this patch fixes the exception problems we used to have. The handling of 401 error should be much better now, and in any case when Proxify detects that a user's access and refresh token expired it should delete the cookie now and try to redirect to the login page (if the redirect URL has been specified).